### PR TITLE
Karma list grep boundary

### DIFF
--- a/playonbsd-irc-bot.sh
+++ b/playonbsd-irc-bot.sh
@@ -67,7 +67,7 @@ update_names()
 	for name in $ACTIVE_NAMES; do
 		# sanitize name
 		name="$(echo "$name" | tr -cd "[:alnum:]_-")"
-		if [ -z "$(grep -E "^$name" "$KARMA_FILE")" ] ; then
+		if [ -z "$(grep -E "^$name:" "$KARMA_FILE")" ] ; then
 			echo "$name:0" >> "$KARMA_FILE"
 		fi
 	done


### PR DESCRIPTION
The grep for sdk would also return sdk_ or sdksomething.
Adding the ":" to the grep avoids matching longer nicks.